### PR TITLE
fix bug #42 unable to run dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,6 @@
     "validate.js": "^0.13.1"
   },
   "devDependencies": {
-    "eslint": "5.16.0",
-    "eslint-plugin-prettier": "^3.0.1",
-    "eslint-plugin-react": "^7.12.4",
     "prettier": "^1.17.1",
     "prettier-eslint": "^8.8.2",
     "prettier-eslint-cli": "^4.7.1",


### PR DESCRIPTION
the bug was when I run "npm i" the error was:
The react-scripts package provided by Create React App requires a dependency: "eslint": "^6.6.0"Don't try to install it manually: your package manager does it automatically.

so I just removed eslint from devDependencies and now it's working now..